### PR TITLE
Display apps categories correctly

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "app-store",
   "vendor": "extensions",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "title": "VTEX App Store",
   "description": "Discover and install the best VTEX Apps",
   "mustUpdateAt": "2019-04-10",

--- a/react/AppGallery.js
+++ b/react/AppGallery.js
@@ -42,7 +42,11 @@ class AppGallery extends Component {
                     name={product.productName}
                     imageUrl={product.items && product.items[0].images[0].imageUrl}
                     shortDescription={product.description}
-                    category={product.categories ? product.categories[0] : ''}
+                    category={
+                      product.categories && product.categories.length && product.categories.length > 0
+                        ? product.categories[0]
+                        : ''
+                    }
                     seller={product.brand}
                     appId={product.linkText}
                     specifications={product.jsonSpecifications}

--- a/react/AppGallery.js
+++ b/react/AppGallery.js
@@ -42,7 +42,7 @@ class AppGallery extends Component {
                     name={product.productName}
                     imageUrl={product.items && product.items[0].images[0].imageUrl}
                     shortDescription={product.description}
-                    category={product.categories[product.categories.length - 1]}
+                    category={product.categories[0]}
                     seller={product.brand}
                     appId={product.linkText}
                     specifications={product.jsonSpecifications}

--- a/react/AppGallery.js
+++ b/react/AppGallery.js
@@ -42,7 +42,7 @@ class AppGallery extends Component {
                     name={product.productName}
                     imageUrl={product.items && product.items[0].images[0].imageUrl}
                     shortDescription={product.description}
-                    category={product.categories[0]}
+                    category={product.categories ? product.categories[0] : ''}
                     seller={product.brand}
                     appId={product.linkText}
                     specifications={product.jsonSpecifications}

--- a/react/AppShelf.js
+++ b/react/AppShelf.js
@@ -109,7 +109,7 @@ class AppShelf extends Component {
                           }
                           shortDescription={product.description}
                           category={
-                            product.categories[0]
+                            product.categories ? product.categories[0] : ''
                           }
                           seller={product.brand}
                           appId={product.linkText}
@@ -132,7 +132,7 @@ class AppShelf extends Component {
                         }
                         shortDescription={product.description}
                         category={
-                          product.categories[0]
+                          product.categories ? product.categories[0]: ''
                         }
                         seller={product.brand}
                         appId={product.linkText}

--- a/react/AppShelf.js
+++ b/react/AppShelf.js
@@ -109,7 +109,7 @@ class AppShelf extends Component {
                           }
                           shortDescription={product.description}
                           category={
-                            product.categories[product.categories.length - 1]
+                            product.categories[0]
                           }
                           seller={product.brand}
                           appId={product.linkText}
@@ -132,7 +132,7 @@ class AppShelf extends Component {
                         }
                         shortDescription={product.description}
                         category={
-                          product.categories[product.categories.length - 1]
+                          product.categories[0]
                         }
                         seller={product.brand}
                         appId={product.linkText}

--- a/react/AppShelf.js
+++ b/react/AppShelf.js
@@ -120,7 +120,7 @@ class AppShelf extends Component {
                     </Slider>
                   </NoSSR>
                 ) : (
-                  <div className="flex flex-column-s flex-row-l flex-wrap-ns items-center mv4">
+                  <div className="flex flex-column-s flex-row-l flex-wrap-ns items-center justify-center mv4">
                     {products.map(product => (
                       <AppItem
                         key={product.productId}

--- a/react/AppShelf.js
+++ b/react/AppShelf.js
@@ -72,6 +72,8 @@ class AppShelf extends Component {
 
   translate = id => this.props.intl.formatMessage({ id: `extensions.${id}` })
 
+  verifyCategories = categories => categories.length && categories.length > 0
+
   render() {
     const { data, specificationFilters, title } = this.props
     const { loading, products } = data
@@ -109,7 +111,7 @@ class AppShelf extends Component {
                           }
                           shortDescription={product.description}
                           category={
-                            product.categories ? product.categories[0] : ''
+                            this.verifyCategories(product.categories) ? product.categories[0] : ''
                           }
                           seller={product.brand}
                           appId={product.linkText}
@@ -132,7 +134,7 @@ class AppShelf extends Component {
                         }
                         shortDescription={product.description}
                         category={
-                          product.categories ? product.categories[0]: ''
+                          this.verifyCategories(product.categories) ? product.categories[0] : ''
                         }
                         seller={product.brand}
                         appId={product.linkText}

--- a/react/Jumbotron.js
+++ b/react/Jumbotron.js
@@ -54,9 +54,7 @@ class Jumbotron extends Component {
           </div>
         </div>
         <div id="home-shelf" className="bg-light-silver flex justify-center">
-          <div className="w-90-ns mw9">
-            <AppGallery homePage collection="137" />
-          </div>
+          <AppGallery homePage collection="137" />
         </div>
         <div
           className={`w-100 dn-s flex-ns justify-center ${

--- a/react/queries/productsQuery.gql
+++ b/react/queries/productsQuery.gql
@@ -1,6 +1,6 @@
 query Products(
   $query: String
-  $category: String
+  $category: String = "50"
   $specificationFilters: [String]
   $priceRange: String
   $collection: String

--- a/react/utils/utils.js
+++ b/react/utils/utils.js
@@ -1,5 +1,5 @@
 export function removeSlashes(text) {
-  return !!text && text.replace(/\//g, '')
+  return text.split('/').filter(t => !!t).pop()
 }
 
 export function imagePath(availableApp, image) {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Display products' categories correctly.

#### What problem is this solving?
The catalog API sends the products' subcategories concatenated inside an array, 
e.g., `[ '/Apps/SmartCkeckout/Customer/' ]`. This PR formats the API response extracting the correct category to be displayed.

#### Types of changes
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
