### PR TITLE
Use correct categoriesIds on gallery query

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "app-store",
   "vendor": "extensions",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "title": "VTEX App Store",
   "description": "Discover and install the best VTEX Apps",
   "mustUpdateAt": "2019-04-10",

--- a/react/AppGallery.js
+++ b/react/AppGallery.js
@@ -66,7 +66,9 @@ const defaultOptions = {
   options: props => ({
     variables: {
       query: props.query,
-      category: props.category || props.product && props.product.categoryId,
+      category: props.category ||
+        props.product && props.product.categoriesIds && props.product.categoriesIds.length > 0 &&
+        props.product.categoriesIds[0].substring(1, props.product.categoriesIds[0].length - 1),
       collection: props.collection,
       specificationFilters: props.specificationFilters || null,
       from: props.from || 0,

--- a/react/ProductContainer.js
+++ b/react/ProductContainer.js
@@ -4,7 +4,6 @@ import { compose, graphql } from 'react-apollo'
 import { Helmet } from 'render'
 
 import availableAppQuery from './queries/availableAppQuery.gql'
-import AppGallery from './AppGallery'
 import ProductDescription from './components/ProductDescription'
 import ProductHeader from './components/ProductHeader'
 import Loading from './components/Loading'


### PR DESCRIPTION
#### What is the purpose of this pull request?
Use the product's `categoriesIds` to search for the recommended products.

#### What problem is this solving?
The catalog API needs all the categories' and subcategories' ids to return the correct result.

#### Types of changes
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
