### PR TITLE
Change vendor back to extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Use of store builder that caused the store not to show up
+- Bad use of store builder that caused the store not to show up
 
 ## [1.0.1] - 2019-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Use of store builder that caused the store not to show up
+
 ## [1.0.1] - 2019-07-29
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "app-store",
-  "vendor": "vtex",
+  "vendor": "extensions",
   "version": "1.0.1",
   "title": "VTEX App Store",
   "description": "Discover and install the best VTEX Apps",


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change the App Store vendor back to account `extensions`

#### What problem is this solving?
Using vendor different from `extensions` in account `extensions` causes the store to not be rendered anymore

#### How should this be manually tested?
You can visit this link and see that the store is present and responsive

#### Screenshots or example usage
None

#### Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
