### PR TITLE
Add a footer existence check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Product page error while elements are being rendered concurrently
+
 ## [1.0.3] - 2019-12-03
 
 ### Added

--- a/react/components/ProductDescription.js
+++ b/react/components/ProductDescription.js
@@ -113,8 +113,8 @@ class ProductDescription extends Component {
   watchScroll = () => {
     const scroll = window.pageYOffset
     const scrollHeight = document.body.scrollHeight
-    const footerSize = document.getElementById('extension-store-footer')
-      .offsetHeight
+    const footer = document.getElementById('extension-store-footer')
+    const footerSize = (footer && footer.offsetHeight) || 0
     const fixed =
       document.documentElement.offsetHeight > window.innerHeight
         ? scroll < scrollHeight - footerSize - window.innerHeight


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add a page footer existence check

#### What problem is this solving?

A product description load problem that happens when the page footer is not yet rendered

#### How should this be manually tested?
*To see the error happening:*
1. Visit the [App Store](https://apps.vtex.com/).
2. Click on the `Social Selling` app, then navigate back to the App Store home. Repeat this interaction a few times without reloading the site. You should notice that sometimes the product description page sometimes does not load correctly.

*To see the fix in action:*
1. Repeat the procedure above, but in [this workspace](https://artur--extensions.myvtex.com/) instead
#### Screenshots or example usage
Page with error:
![image](https://user-images.githubusercontent.com/3827456/79242930-53b15900-7e4b-11ea-8dfe-f2d04b6c588e.png)

#### Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
