### PR TITLE
Raise app shelf limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Home search with limited results. Now it can contain up to 50 apps
+
 ## [1.0.4] - 2020-04-14
 
 ### Fixed

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -9,14 +9,14 @@
   "app-shelf#published": {
     "props": {
       "specificationFilters": "Published",
-      "to": 12,
+      "to": 49,
       "title": "apps"
     }
   },
   "app-shelf#soon": {
     "props": {
       "specificationFilters": "Coming Soon",
-      "to": 12,
+      "to": 49,
       "title": "comingSoon"
     }
   },


### PR DESCRIPTION
#### What is the purpose of this pull request?

Raise App Store home's shelf limit

#### What problem is this solving?

Some apps were missing from the Homepage due to a search for a very slim page of products

#### How should this be manually tested?

Visit [this linked workspace](https://artur--extensions.myvtex.com/). It should contain all App Store active apps (17 in total)

#### Screenshots or example usage
None

#### Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
