### PR TITLE
Change ' to " in the confirmText definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Strange `{confirmButton}` string showing up in the Review Page
+
 ## [1.0.5] - 2020-04-14
 
 ### Fixed

--- a/messages/en.json
+++ b/messages/en.json
@@ -6,7 +6,7 @@
   "extensions.back": "Back",
   "extensions.reviewOrder": "Review your order",
   "extensions.confirmText":
-    "by clicking in '{confirmButton}' you are agreeing to the {termsOfService} and app {privacyPolice}",
+    "by clicking in \"{confirmButton}\" you are agreeing to the {termsOfService} and app {privacyPolice}",
   "extensions.termsOfService": "app store terms of service",
   "extensions.privacyPolice": "privacy policy",
   "extensions.confirmButton": "confirm order and begin installation",

--- a/messages/es.json
+++ b/messages/es.json
@@ -6,7 +6,7 @@
   "extensions.back": "Volver",
   "extensions.reviewOrder": "Ver su pedido",
   "extensions.confirmText":
-    "haciendo clic en '{confirmButton}' usted está de acuerdo con los {termsOfService} y con la {privacyPolice} de la app",
+    "haciendo clic en \"{confirmButton}\" usted está de acuerdo con los {termsOfService} y con la {privacyPolice} de la app",
   "extensions.termsOfService": "términos de servicio de la app store",
   "extensions.privacyPolice": "política de privacidad",
   "extensions.confirmButton": "confirmar pedido e iniciar instalación",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -6,7 +6,7 @@
   "extensions.back": "Voltar",
   "extensions.reviewOrder": "Confira seu pedido",
   "extensions.confirmText":
-    "clicando em '{confirmButton}' você está concordando com os {termsOfService} e com a {privacyPolice} da app",
+    "clicando em \"{confirmButton}\" você está concordando com os {termsOfService} e com a {privacyPolice} da app",
   "extensions.termsOfService": "termos de serviço da app store",
   "extensions.privacyPolice": "política de privacidade",
   "extensions.confirmButton": "confirmar pedido e iniciar instalação",


### PR DESCRIPTION
#### What is the purpose of this pull request?

Use a different quote mark in the `confirmText` message

#### What problem is this solving?

Usage of single quote marks causes the brackets `{}` to be interpreted as-is

#### How should this be manually tested?

Current:
1. Visit this [Review Page](https://apps.vtex.com/google-shopping/r)
2. See that in the text above the button, a `{confirmButton}` string appears

Fixed:
1. Visit this [linked Review Page](https://artur--extensions.myvtex.com/google-shopping/r)
2. Now the text contain the actual content of the `extensions.confirmButton` message

#### Screenshots or example usage
**Current:**
![image](https://user-images.githubusercontent.com/3827456/79615183-89b73d00-80d8-11ea-8025-b1ef5be70ae1.png)
**Fixed:**
![image](https://user-images.githubusercontent.com/3827456/79615210-9b004980-80d8-11ea-87dd-1284483d706e.png)

#### Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
