### PR TITLE
Equalize shelves widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Adjust all product shelves to have the same length
+
 ## [1.0.6] - 2020-04-22
 
 ### Fixed

--- a/react/AppGallery.js
+++ b/react/AppGallery.js
@@ -35,7 +35,7 @@ class AppGallery extends Component {
               </div>
             ) : (
               <div
-                className={`mw9 w-100 flex flex-column-s flex-row-l flex-wrap-ns justify-center items-center ${
+                className={`mw9 nh5-ns w-100 flex flex-column-s flex-row-l flex-wrap-ns justify-between items-center ${
                   homePage ? 'relative card-top' : 'mv4'
                 }`}
               >

--- a/react/AppGallery.js
+++ b/react/AppGallery.js
@@ -35,7 +35,7 @@ class AppGallery extends Component {
               </div>
             ) : (
               <div
-                className={`mw9 nh5-ns w-100 flex flex-column-s flex-row-l flex-wrap-ns justify-between items-center ${
+                className={`mw9 nh5-ns w-100 flex flex-column-s flex-row-l flex-wrap-ns justify-center items-center ${
                   homePage ? 'relative card-top' : 'mv4'
                 }`}
               >

--- a/react/AppShelf.js
+++ b/react/AppShelf.js
@@ -125,7 +125,7 @@ class AppShelf extends Component {
                   </NoSSR>
                 ) : (
                   <div className="w-100 flex justify-center">
-                    <div className="flex flex-column flex-row-ns flex-wrap-ns mv4 justify-center justify-between-ns">
+                    <div className="flex flex-column flex-row-ns flex-wrap-ns mv4 justify-center">
                       {products.map((product) => (
                         <AppItem
                           key={product.productId}

--- a/react/AppShelf.js
+++ b/react/AppShelf.js
@@ -100,7 +100,7 @@ class AppShelf extends Component {
                       scrollByPage={isScrollByPage}
                       defaultItemWidth={DEFAULT_SHELF_ITEM_WIDTH}
                     >
-                      {products.map(product => (
+                      {products.map((product) => (
                         <AppItem
                           key={product.productId}
                           name={product.productName}
@@ -111,7 +111,9 @@ class AppShelf extends Component {
                           }
                           shortDescription={product.description}
                           category={
-                            this.verifyCategories(product.categories) ? product.categories[0] : ''
+                            this.verifyCategories(product.categories)
+                              ? product.categories[0]
+                              : ""
                           }
                           seller={product.brand}
                           appId={product.linkText}
@@ -123,8 +125,8 @@ class AppShelf extends Component {
                   </NoSSR>
                 ) : (
                   <div className="w-100 flex justify-center">
-                    <div className="w-80 flex flex-column-s flex-row-l flex-wrap-ns mv4">
-                      {products.map(product => (
+                    <div className="flex flex-column flex-row-ns flex-wrap-ns mv4 justify-center justify-between-ns">
+                      {products.map((product) => (
                         <AppItem
                           key={product.productId}
                           name={product.productName}
@@ -135,7 +137,9 @@ class AppShelf extends Component {
                           }
                           shortDescription={product.description}
                           category={
-                            this.verifyCategories(product.categories) ? product.categories[0] : ''
+                            this.verifyCategories(product.categories)
+                              ? product.categories[0]
+                              : ""
                           }
                           seller={product.brand}
                           appId={product.linkText}
@@ -143,6 +147,8 @@ class AppShelf extends Component {
                           isShelf={isMobileOnly}
                         />
                       ))}
+                      <Filler />
+                      <Filler />
                     </div>
                   </div>
                 )}
@@ -151,9 +157,15 @@ class AppShelf extends Component {
           </div>
         </div>
       </div>
-    )
+    );
   }
 }
+
+/*
+* OBS: This is a workaround to maintain left-alignment in the justified product shelf.
+* The flexbox does not yet support this kind of arrangement
+*/
+const Filler = () => <div className="w-33-ns ph5-ns" />;
 
 const defaultOptions = {
   options: props => ({

--- a/react/Jumbotron.js
+++ b/react/Jumbotron.js
@@ -1,11 +1,11 @@
 import React, { Component } from 'react'
 import { injectIntl, intlShape } from 'react-intl'
 import { Helmet } from 'vtex.render-runtime'
+import { Tag } from 'vtex.styleguide'
 
 import AppGallery from './AppGallery'
 import JumbotronIcon from './components/icons/JumbotronIcon'
 import SearchBox from './components/SearchBox'
-import { Badge } from 'vtex.styleguide'
 
 class Jumbotron extends Component {
   static propTypes = {
@@ -45,7 +45,7 @@ class Jumbotron extends Component {
           <div className="flex-ns w-100 mw9">
             <div className="w-100 pl5 pr6">
             <span className="mr4">
-              <Badge bgColor="#F71963" color="#FFFFFF">Beta</Badge>
+              <Tag bgColor="#F71963" color="#FFFFFF">Beta</Tag>
             </span>
               <div className="f2 fw5 mt5 pb5 lh-title">VTEX App Store</div>
               <div className="w-80-l mt5 mb9-ns f4 fw3 lh-copy">

--- a/react/components/AppItem.js
+++ b/react/components/AppItem.js
@@ -76,31 +76,33 @@ class AppItem extends Component {
     return (
       <div
         onClick={this.handleClick}
-        className={`link no-underline db mt5-s mt0-ns ma4-s ma5-ns ${
-          isShelf ? '' : 'w-90-s w-50-m w-30-l'
-        } ${isComing ? '' : 'pointer card-hover'}`}
+        className={`link no-underline db pt5-s pt0-ns pa4-s pa5-ns ${
+          isShelf ? '' : 'w-90-s w-50-m w-33-l'
+        }`}
       >
-        <Card>
-          <div className="flex flex-row near-black">
-            <AppIcon imageUrl={imageUrl} name={name} />
-            <div className="w-100 ml5 flex flex-column justify-center lh-copy">
-              <div className="title-height-s h2-ns overflow-y-hidden f5-s f4-ns fw5 mb4-ns">
-                {name}
-              </div>
-              {!isComing && (
-                <div className="w-60">
-                  <GetButton appId={appId} homePage />
+        <div className={`w-100 ${isComing ? '' : 'pointer card-hover'}`}>
+          <Card>
+            <div className="flex flex-row near-black">
+              <AppIcon imageUrl={imageUrl} name={name} />
+              <div className="w-100 ml5 flex flex-column justify-center lh-copy">
+                <div className="title-height-s h2-ns overflow-y-hidden f5-s f4-ns fw5 mb4-ns">
+                  {name}
                 </div>
-              )}
+                {!isComing && (
+                  <div className="w-60">
+                    <GetButton appId={appId} homePage />
+                  </div>
+                )}
+              </div>
             </div>
-          </div>
-          <div className="description-height ">
-            <div className="mv5 overflow-hidden f5 fw4 dark-gray track-1 block-with-text">
-              {this.getLocaleDescription(shortDescription)}
+            <div className="description-height ">
+              <div className="mv5 overflow-hidden f5 fw4 dark-gray track-1 block-with-text">
+                {this.getLocaleDescription(shortDescription)}
+              </div>
             </div>
-          </div>
-          <AppCategory category={category} seller={seller} homePage />
-        </Card>
+            <AppCategory category={category} seller={seller} homePage />
+          </Card>
+        </div>
       </div>
     )
   }

--- a/react/components/SearchBox.js
+++ b/react/components/SearchBox.js
@@ -34,7 +34,7 @@ class SearchBox extends Component {
   render() {
     const { searchValue, shouldHaveBorder } = this.state
     return (
-      <div className="w-100 h-100">
+      <div className="w-100 h-100 ph5-ns">
         <div className="flex flex-row w-100 bg-white gray">
           <div className="flex items-center bb bw1 b--rebel-pink ph3-ns ph6-s pv3">
             <SearchIcon colorFill="gray" />


### PR DESCRIPTION
#### What is the purpose of this pull request?

Enlarge Home's app shelves in order to make them all the same width.

#### What problem is this solving?

This gives more space for card content, and also makes the store's shelves look more consistent

#### How should this be manually tested?

You can check this out in this [linked workspace](https://artur--extensions.myvtex.com/)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/3827456/80288435-48ddaa80-870e-11ea-88a8-952251fd0d70.png)

#### Types of changes

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
